### PR TITLE
Re-architecture app, add "Save & Preview" (and similar) buttons

### DIFF
--- a/Remote Text.xcodeproj/project.pbxproj
+++ b/Remote Text.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		221B22AE2A010F490042B0AB /* FileListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 221B22AD2A010F490042B0AB /* FileListView.swift */; };
+		221B22B02A0110010042B0AB /* ServerUnreachable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 221B22AF2A0110010042B0AB /* ServerUnreachable.swift */; };
+		2253923E2A01A76B00DFB01B /* PreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2253923D2A01A76B00DFB01B /* PreviewView.swift */; };
 		2266D60129F510E800DC8128 /* PDFDocument+Transferable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2266D60029F510E800DC8128 /* PDFDocument+Transferable.swift */; };
 		22A1A13D29E0D3DA00D26FCC /* SFSafeSymbols in Frameworks */ = {isa = PBXBuildFile; productRef = 22A1A13C29E0D3DA00D26FCC /* SFSafeSymbols */; };
 		22A1A13F29E0D71000D26FCC /* CreateFileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22A1A13E29E0D71000D26FCC /* CreateFileView.swift */; };
@@ -23,6 +26,9 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		221B22AD2A010F490042B0AB /* FileListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileListView.swift; sourceTree = "<group>"; };
+		221B22AF2A0110010042B0AB /* ServerUnreachable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerUnreachable.swift; sourceTree = "<group>"; };
+		2253923D2A01A76B00DFB01B /* PreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewView.swift; sourceTree = "<group>"; };
 		2266D60029F510E800DC8128 /* PDFDocument+Transferable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "PDFDocument+Transferable.swift"; sourceTree = "<group>"; };
 		22A1A13E29E0D71000D26FCC /* CreateFileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateFileView.swift; sourceTree = "<group>"; };
 		22A1A14029E0D72200D26FCC /* FileDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileDetailView.swift; sourceTree = "<group>"; };
@@ -81,6 +87,9 @@
 				231BDB3229DF6C990024D52C /* Preview Content */,
 				22A1A13E29E0D71000D26FCC /* CreateFileView.swift */,
 				22A1A14029E0D72200D26FCC /* FileDetailView.swift */,
+				221B22AD2A010F490042B0AB /* FileListView.swift */,
+				221B22AF2A0110010042B0AB /* ServerUnreachable.swift */,
+				2253923D2A01A76B00DFB01B /* PreviewView.swift */,
 			);
 			path = "Remote Text";
 			sourceTree = "<group>";
@@ -176,11 +185,14 @@
 				22A1A13F29E0D71000D26FCC /* CreateFileView.swift in Sources */,
 				2365DC8C29F5E175007E8C12 /* HtmlDocument.swift in Sources */,
 				22A1A14129E0D72200D26FCC /* FileDetailView.swift in Sources */,
+				2253923E2A01A76B00DFB01B /* PreviewView.swift in Sources */,
 				231BDB2B29DF6C980024D52C /* Remote_TextApp.swift in Sources */,
 				2266D60129F510E800DC8128 /* PDFDocument+Transferable.swift in Sources */,
+				221B22AE2A010F490042B0AB /* FileListView.swift in Sources */,
 				231BDB3E29DF6EAB0024D52C /* Structs.swift in Sources */,
 				231BDB3C29DF6E810024D52C /* FileModel.swift in Sources */,
 				231BDB2F29DF6C980024D52C /* ContentView.swift in Sources */,
+				221B22B02A0110010042B0AB /* ServerUnreachable.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Remote Text/ContentView.swift
+++ b/Remote Text/ContentView.swift
@@ -32,6 +32,8 @@ struct ContentView: View {
     
     @State private var taskId: UUID = .init()
     
+//    @State private var navPath = NavigationPath()
+    
     var filesList: some View {
         Group {
             if files.isEmpty {
@@ -92,7 +94,7 @@ struct ContentView: View {
     }
     
     var body: some View {
-        NavigationStack {
+        NavigationStack(path: $model.path) {
             ZStack {
                 filesList
                 if self.unreachable {

--- a/Remote Text/ContentView.swift
+++ b/Remote Text/ContentView.swift
@@ -11,140 +11,43 @@ import SFSafeSymbols
 struct ContentView: View {
     
     @ObservedObject var model: FileModel
-    
-    @State private var _id: String = ""
-    private var id: UUID? {
-        UUID(uuidString: _id)
-    }
-    
-    @State private var data = ""
-    @State private var hash: String = ""
-    @State private var name: String = ""
-    @State private var content: String = ""
     @State var files: [FileSummary] = []
     
     @State private var isLoading = false
     
     let timer = Timer.publish(every: 15, on: .main, in: .common).autoconnect()
     
-    @State var deleting = false
     @State var unreachable = false
     
     @State private var taskId: UUID = .init()
     
-//    @State private var navPath = NavigationPath()
-    
-    var filesList: some View {
-        Group {
-            if files.isEmpty {
-                Text("No Files")
-                    .font(.body.lowercaseSmallCaps())
-                    .foregroundColor(.gray)
-            } else {
-                ScrollView(.vertical) {
-                    LazyVGrid(columns: [GridItem(.adaptive(minimum: 150))]) {
-                        ForEach(files) { file in
-                            if deleting {
-                                VStack {
-                                    ZStack(alignment: .topLeading) {
-                                        Image(systemSymbol: .docText)
-                                            .font(.largeTitle)
-                                            .imageScale(.large)
-                                        Button {
-                                            self.files = self.files.filter { $0.id != file.id }
-                                            Task {
-                                                await model.deleteFile(id: file.id)
-                                            }
-                                        } label: {
-                                            Image(systemSymbol: .minusCircleFill)
-                                                .foregroundColor(.red)
-                                                .background(in: Circle())
-                                        }
-                                    }
-                                    Text(file.name)
-                                }
-                                .padding()
-                            } else {
-                                NavigationLink {
-                                    FileDetailView(file, model)
-                                } label: {
-                                    VStack {
-                                        Image(systemSymbol: .docText)
-                                            .font(.largeTitle)
-                                            .imageScale(.large)
-                                        Text(file.name)
-                                    }
-                                }
-                                .padding()
-                                .simultaneousGesture(LongPressGesture()
-                                    .onEnded { finished in
-                                        print("Gesture complete")
-                                        self.deleting = true
-                                    })
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        .refreshable {
-            print("Loading files (drag)")
-            taskId = .init()
-        }
+    public enum Navigation: Hashable {
+//        case listFiles
+        case fileEditor(file: FileSummary)
+        case fileCreator
+        case previewFile(id: UUID, hash: String, filename: String)
     }
     
     var body: some View {
         NavigationStack(path: $model.path) {
-            ZStack {
-                filesList
-                if self.unreachable {
-                    VStack {
-                        Spacer()
-                        HStack {
-                            Spacer()
-                            Text("Server Unreachable")
-                                .font(.body.lowercaseSmallCaps())
-                                .padding()
-                                .background(.red)
-                                .cornerRadius(5)
-                                .transition(.asymmetric(insertion: .push(from: .bottom), removal: .scale))
-                            Spacer()
-                        }
+            FileListView(files: self.$files)
+                .navigationDestination(for: Navigation.self) { nav in
+                    switch nav {
+//                    case .listFiles
+                    case .fileEditor(let file):
+                        FileDetailView(file)
+                    case .fileCreator:
+                        CreateFileView()
+                    case let .previewFile(id, hash, filename):
+                        PreviewView(id, hash, filename)
                     }
                 }
-            }
-            .toolbar {
-                ToolbarItem(placement: .navigationBarLeading) {
-                    if isLoading {
-                        ProgressView()
-                    } else {
-                        Button {
-                            print("Loading files (button)")
-                            self.taskId = .init()
-                        } label: {
-                            Image(systemSymbol: .arrowClockwise)
-                        }
-                    }
-                }
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    if deleting {
-                        Button {
-                            self.deleting = false
-                        } label: {
-                            Text("Done")
-                        }
-                    } else {
-                        NavigationLink {
-                            CreateFileView(model: model)
-                        } label: {
-                            Image(systemSymbol: .plus)
-                        }.padding()
-                    }
-                }
-            }
         }
+        .environment(\.refresh, { self.taskId = .init() })
+        .environment(\.isLoading, self.isLoading)
+        .environment(\.unreachable, self.unreachable)
+        .environmentObject(model)
         .onReceive(timer) { input in
-            print("Loading files (periodic)")
             self.taskId = .init()
         }
         .task(id: taskId) {
@@ -162,6 +65,11 @@ struct ContentView: View {
                     withAnimation {
                         self.unreachable = true
                     }
+                case URLError.notConnectedToInternet:
+                    withAnimation {
+                        //i.e., internet is off
+                        self.unreachable = true
+                    }
                 default:
                     print("URLError \(error.code)")
                 }
@@ -170,5 +78,30 @@ struct ContentView: View {
             }
             self.isLoading = false
         }
+    }
+}
+
+struct RefreshKey: EnvironmentKey {
+    static let defaultValue: () -> Void = {}
+}
+struct IsLoadingKey: EnvironmentKey {
+    static let defaultValue: Bool = false
+}
+struct UnreachableKey: EnvironmentKey {
+    static let defaultValue: Bool = false
+}
+
+extension EnvironmentValues {
+    var refresh: () -> Void {
+        get { self[RefreshKey.self] }
+        set { self[RefreshKey.self] = newValue }
+    }
+    var isLoading: Bool {
+        get { self[IsLoadingKey.self] }
+        set { self[IsLoadingKey.self] = newValue }
+    }
+    var unreachable: Bool {
+        get { self[UnreachableKey.self] }
+        set { self[UnreachableKey.self] = newValue }
     }
 }

--- a/Remote Text/FileDetailView.swift
+++ b/Remote Text/FileDetailView.swift
@@ -8,37 +8,21 @@
 import SwiftUI
 import HighlightedTextEditor
 import CodeEditor
-import PDFKit
-import WebKit
-import Combine
 
 struct FileDetailView: View {
-    
-    @Environment(\.dismiss) var dismiss
-    @ObservedObject var model: FileModel
+    @EnvironmentObject var model: FileModel
   
     @State var hash: String = ""
     @State var fileName = ""
     @State var content = ""
     @State private var loading = true
     @State private var initialContent = ""
-    
-////    @State private var triggerPreview = PassthroughSubject<(()
-//    @State private var jumpToPreview = JumpToPreview.waiting
-//    private enum JumpToPreview {
-//        case waiting, engaged
-//    }
   
     private let id: UUID
 
-    init(_ file: FileSummary, _ model: FileModel) {
+    init(_ file: FileSummary) {
         self.id = file.id
         self._fileName = State(wrappedValue: file.name)
-        self.model = model
-    }
-    
-    enum MyNav {
-        case preview
     }
     
     var body: some View {
@@ -90,9 +74,7 @@ struct FileDetailView: View {
                 .toolbar {
                     if self.initialContent == self.content {
                         ToolbarItem(placement: .navigationBarTrailing) {
-                            NavigationLink {
-                                PreviewView(id, model, hash, fileName)
-                            } label: {
+                            NavigationLink(value: ContentView.Navigation.previewFile(id: id, hash: hash, filename: fileName)) {
                                 Text("Preview")
                             }
                         }
@@ -111,28 +93,19 @@ struct FileDetailView: View {
                                 Button {
                                     Task {
                                         await model.saveFile(id: id, name: fileName, content: content, parentCommit: hash, branch: "main")
-                                        self.dismiss.callAsFunction()
+                                        self.model.path.removeLast()
                                     }
                                 } label: {
                                     Text("Save & Close")
                                 }
                             } label: {
-//                                NavigationLink(tag: JumpToPreview.engaged, selection: $jumpToPreview) {
-//                                    PreviewView(id, model, hash, fileName)
-//                                } label: {
-//
-//                                }
                                 Text("Save & Preview")
                             } primaryAction: {
                                 Task {
                                     let res = await model.saveFile(id: id, name: fileName, content: content, parentCommit: hash, branch: "main")
                                     self.hash = res.hash
                                     self.initialContent = self.content
-                                    //How to add onto navigation stack?
-                                    dump(self.model.path)
-                                    self.model.path.append(MyNav.preview)
-                                    dump(self.model.path)
-//                                    NavigationLink.init(value: <#T##Hashable?#>, label: <#T##() -> View#>)
+                                    self.model.path.append(ContentView.Navigation.previewFile(id: id, hash: self.hash, filename: self.fileName))
                                 }
                             }
                             .disabled(fileName.isEmpty)
@@ -140,164 +113,6 @@ struct FileDetailView: View {
                     }
                 }
             }
-        }.navigationDestination(for: MyNav.self) { myNav in
-            switch myNav {
-            case .preview:
-                PreviewView(id, model, hash, fileName)
-            }
         }
-    }
-}
-
-struct PreviewView: View {
-    private let id: UUID
-    private let model: FileModel
-    private let hash: String
-    private let filename: String
-    
-    @State private var state: PreviewState = .loading
-    @State private var data: Data = Data()
-    @State private var log: String = ""
-    @State private var type: PreviewType = .HTML
-  
-    @State private var pdfDocument: PDFDocument = PDFDocument()
-    @State private var htmlDocument: HTMLDocument = HTMLDocument()
-    @State private var previewImage: Image = Image("")
-    
-    init(_ id: UUID, _ model: FileModel, _ hash: String, _ filename: String) {
-        self.id = id
-        self.model = model
-        self.hash = hash
-        self.filename = filename
-    }
-    
-    enum PreviewState {
-        case loading
-        case previewFailed, previewSucceeded
-        case previewFetched
-    }
-    
-    var body: some View {
-        switch state {
-        case .loading:
-            VStack {
-                ProgressView()
-                Text("Previewing file")
-            }
-            .navigationTitle("Previewing file")
-            .onAppear {
-                Task {
-                    let comp = await model.previewFile(id: id, atVersion: hash)
-                    switch comp.state {
-                    case .SUCCESS:
-                        self.state = .previewSucceeded
-                        self.log = comp.log
-                    case .FAILURE:
-                        self.state = .previewFailed
-                        self.log = comp.log
-                    }
-                }
-            }
-        case .previewFailed:
-            VStack {
-                Text("Preview unsuccessful")
-                    .font(.title)
-                ScrollView(.vertical) {
-                    Text(log)
-                        .lineLimit(nil)
-                }
-            }
-            .navigationTitle("Preview unsuccessful")
-        case .previewSucceeded:
-            VStack {
-                ProgressView()
-                Text("Fetching preview")
-            }
-            .navigationTitle("Fetching preview")
-            .onAppear {
-                Task {
-                    let (data, type) = await model.getPreview(id: id, atVersion: hash)
-                    self.data = data
-                    self.state = .previewFetched
-                    self.type = type
-                }
-            }
-        case .previewFetched:
-            switch self.type {
-            case .PDF:
-                PDFKitRepresentedView(data)
-                    .navigationTitle(filename.replacing(/\.tex$/, with: ".pdf"))
-                    .toolbar {
-                        ToolbarItem(placement: .navigationBarTrailing) {
-                            ShareLink(item: pdfDocument,
-                                      preview: SharePreview(
-                                        filename.replacing(/\.tex$/, with: ".pdf"),
-                                        image: previewImage
-                                      )
-                            )
-                        }
-                    }
-                    .onAppear {
-                        guard let pdf = PDFDocument(data: data),
-                              let image = pdf.imageRepresenation else {
-                            fatalError("something went wrong...")
-                        }
-                        
-                        pdf.documentAttributes![PDFDocumentAttribute.titleAttribute] = filename
-                        self.pdfDocument = pdf
-                        self.previewImage = Image(uiImage: image)
-                    }
-            case .HTML:
-                WebView(self.data)
-                    .navigationTitle(filename.replacing(/\..+$/, with: ".html"))
-                    .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity)
-                    .toolbar {
-                        ToolbarItem(placement: .navigationBarTrailing) {
-                          ShareLink(item: htmlDocument,
-                                      preview: SharePreview(
-                                        filename.replacing(/\..+$/, with: ".html")
-                                      )
-                            )
-                        }
-                    }
-                    .onAppear {
-                      self.htmlDocument = HTMLDocument(title: filename, source: data)
-                    }
-            }
-        }
-    }
-}
-
-struct PDFKitRepresentedView: UIViewRepresentable {
-    let data: Data
-
-    init(_ data: Data) {
-        self.data = data
-    }
-
-    func makeUIView(context: UIViewRepresentableContext<PDFKitRepresentedView>) -> PDFKitRepresentedView.UIViewType {
-        // Create a `PDFView` and set its `PDFDocument`.
-        let pdfView = PDFView()
-        pdfView.document = PDFDocument(data: data)
-        return pdfView
-    }
-
-    func updateUIView(_ uiView: UIView, context: UIViewRepresentableContext<PDFKitRepresentedView>) {
-        // Update the view.
-    }
-}
-struct WebView: UIViewRepresentable {
-    let source: String
-    
-    init(_ data: Data) {
-        self.source = String(bytes: data, encoding: .utf8)!
-    }
-    
-    func makeUIView(context: Context) -> WKWebView {
-        return WKWebView()
-    }
-    
-    func updateUIView(_ uiView: WKWebView, context: Context) {
-        uiView.loadHTMLString(source, baseURL: nil)
     }
 }

--- a/Remote Text/FileListView.swift
+++ b/Remote Text/FileListView.swift
@@ -1,0 +1,112 @@
+//
+//  FileListView.swift
+//  Remote Text
+//
+//  Created by Sam Gauck on 5/2/23.
+//
+
+import SwiftUI
+
+
+struct FileListView: View {
+    @Environment(\.refresh) var refresh: () -> Void
+    @Environment(\.isLoading) var isLoading: Bool
+    @Environment(\.unreachable) var unreachable: Bool
+    
+    @EnvironmentObject var model: FileModel
+    
+    @State private var deleting: Bool = false
+    
+    @Binding var files: [FileSummary]
+    
+    init(files: Binding<[FileSummary]>) {
+        self._files = files
+    }
+    
+    var body: some View {
+        filesList
+            .unreachable(self.unreachable)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    if isLoading {
+                        ProgressView()
+                    } else {
+                        Button {
+                            self.refresh()
+                        } label: {
+                            Image(systemSymbol: .arrowClockwise)
+                        }
+                    }
+                }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    if deleting {
+                        Button {
+                            self.deleting = false
+                        } label: {
+                            Text("Done")
+                        }
+                    } else {
+                        NavigationLink(value: ContentView.Navigation.fileCreator) {
+                            Image(systemSymbol: .plus)
+                        }.padding()
+                    }
+                }
+            }
+    }
+    
+    var filesList: some View {
+        Group {
+            if files.isEmpty {
+                Text("No Files")
+                    .font(.body.lowercaseSmallCaps())
+                    .foregroundColor(.gray)
+            } else {
+                ScrollView(.vertical) {
+                    LazyVGrid(columns: [GridItem(.adaptive(minimum: 150))]) {
+                        ForEach(files) { file in
+                            if deleting {
+                                VStack {
+                                    ZStack(alignment: .topLeading) {
+                                        Image(systemSymbol: .docText)
+                                            .font(.largeTitle)
+                                            .imageScale(.large)
+                                        Button {
+                                            self.files = self.files.filter { $0.id != file.id }
+                                            Task {
+                                                await model.deleteFile(id: file.id)
+                                            }
+                                        } label: {
+                                            Image(systemSymbol: .minusCircleFill)
+                                                .foregroundColor(.red)
+                                                .background(in: Circle())
+                                        }
+                                    }
+                                    Text(file.name)
+                                }
+                                .padding()
+                            } else {
+                                NavigationLink(value: ContentView.Navigation.fileEditor(file: file)) {
+                                    VStack {
+                                        Image(systemSymbol: .docText)
+                                            .font(.largeTitle)
+                                            .imageScale(.large)
+                                        Text(file.name)
+                                    }
+                                }
+                                .padding()
+                                .simultaneousGesture(LongPressGesture()
+                                    .onEnded { finished in
+                                        print("Gesture complete")
+                                        self.deleting = true
+                                    })
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .refreshable {
+            self.refresh()
+        }
+    }
+}

--- a/Remote Text/FileModel.swift
+++ b/Remote Text/FileModel.swift
@@ -12,7 +12,8 @@ class FileModel: ObservableObject {
   
     static let shared = FileModel()
     
-    @Published var path = NavigationPath()
+//    @Published var path = NavigationPath()
+    @Published var path: [ContentView.Navigation] = []
     
     private func request(to endpoint: String, with data: Codable?) throws -> URLRequest {
         let BASE_URL = "http://localhost:3030/api"

--- a/Remote Text/FileModel.swift
+++ b/Remote Text/FileModel.swift
@@ -6,10 +6,13 @@
 //
 
 import Foundation
+import SwiftUI
 
 class FileModel: ObservableObject {
   
     static let shared = FileModel()
+    
+    @Published var path = NavigationPath()
     
     private func request(to endpoint: String, with data: Codable?) throws -> URLRequest {
         let BASE_URL = "http://localhost:3030/api"

--- a/Remote Text/PreviewView.swift
+++ b/Remote Text/PreviewView.swift
@@ -1,0 +1,163 @@
+//
+//  PreviewView.swift
+//  Remote Text
+//
+//  Created by Sam Gauck on 5/2/23.
+//
+
+import SwiftUI
+import PDFKit
+import WebKit
+
+struct PreviewView: View {
+    @EnvironmentObject var model: FileModel
+    
+    private let id: UUID
+    private let hash: String
+    private let filename: String
+    
+    @State private var state: PreviewState = .loading
+    @State private var data: Data = Data()
+    @State private var log: String = ""
+    @State private var type: PreviewType = .HTML
+  
+    @State private var pdfDocument: PDFDocument = PDFDocument()
+    @State private var htmlDocument: HTMLDocument = HTMLDocument()
+    @State private var previewImage: Image = Image("")
+    
+    init(_ id: UUID, _ hash: String, _ filename: String) {
+        self.id = id
+        self.hash = hash
+        self.filename = filename
+    }
+    
+    enum PreviewState {
+        case loading
+        case previewFailed, previewSucceeded
+        case previewFetched
+    }
+    
+    var body: some View {
+        switch state {
+        case .loading:
+            VStack {
+                ProgressView()
+                Text("Previewing file")
+            }
+            .navigationTitle("Previewing file")
+            .onAppear {
+                Task {
+                    let comp = await model.previewFile(id: id, atVersion: hash)
+                    switch comp.state {
+                    case .SUCCESS:
+                        self.state = .previewSucceeded
+                        self.log = comp.log
+                    case .FAILURE:
+                        self.state = .previewFailed
+                        self.log = comp.log
+                    }
+                }
+            }
+        case .previewFailed:
+            VStack {
+                Text("Preview unsuccessful")
+                    .font(.title)
+                ScrollView(.vertical) {
+                    Text(log)
+                        .lineLimit(nil)
+                }
+            }
+            .navigationTitle("Preview unsuccessful")
+        case .previewSucceeded:
+            VStack {
+                ProgressView()
+                Text("Fetching preview")
+            }
+            .navigationTitle("Fetching preview")
+            .onAppear {
+                Task {
+                    let (data, type) = await model.getPreview(id: id, atVersion: hash)
+                    self.data = data
+                    self.state = .previewFetched
+                    self.type = type
+                }
+            }
+        case .previewFetched:
+            switch self.type {
+            case .PDF:
+                PDFKitRepresentedView(data)
+                    .navigationTitle(filename.replacing(/\.tex$/, with: ".pdf"))
+                    .toolbar {
+                        ToolbarItem(placement: .navigationBarTrailing) {
+                            ShareLink(item: pdfDocument,
+                                      preview: SharePreview(
+                                        filename.replacing(/\.tex$/, with: ".pdf"),
+                                        image: previewImage
+                                      )
+                            )
+                        }
+                    }
+                    .onAppear {
+                        guard let pdf = PDFDocument(data: data),
+                              let image = pdf.imageRepresenation else {
+                            fatalError("something went wrong...")
+                        }
+                        
+                        pdf.documentAttributes![PDFDocumentAttribute.titleAttribute] = filename
+                        self.pdfDocument = pdf
+                        self.previewImage = Image(uiImage: image)
+                    }
+            case .HTML:
+                WebView(self.data)
+                    .navigationTitle(filename.replacing(/\..+$/, with: ".html"))
+                    .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity)
+                    .toolbar {
+                        ToolbarItem(placement: .navigationBarTrailing) {
+                          ShareLink(item: htmlDocument,
+                                      preview: SharePreview(
+                                        filename.replacing(/\..+$/, with: ".html")
+                                      )
+                            )
+                        }
+                    }
+                    .onAppear {
+                      self.htmlDocument = HTMLDocument(title: filename, source: data)
+                    }
+            }
+        }
+    }
+}
+
+struct PDFKitRepresentedView: UIViewRepresentable {
+    let data: Data
+
+    init(_ data: Data) {
+        self.data = data
+    }
+
+    func makeUIView(context: UIViewRepresentableContext<PDFKitRepresentedView>) -> PDFKitRepresentedView.UIViewType {
+        // Create a `PDFView` and set its `PDFDocument`.
+        let pdfView = PDFView()
+        pdfView.document = PDFDocument(data: data)
+        return pdfView
+    }
+
+    func updateUIView(_ uiView: UIView, context: UIViewRepresentableContext<PDFKitRepresentedView>) {
+        // Update the view.
+    }
+}
+struct WebView: UIViewRepresentable {
+    let source: String
+    
+    init(_ data: Data) {
+        self.source = String(bytes: data, encoding: .utf8)!
+    }
+    
+    func makeUIView(context: Context) -> WKWebView {
+        return WKWebView()
+    }
+    
+    func updateUIView(_ uiView: WKWebView, context: Context) {
+        uiView.loadHTMLString(source, baseURL: nil)
+    }
+}

--- a/Remote Text/ServerUnreachable.swift
+++ b/Remote Text/ServerUnreachable.swift
@@ -1,0 +1,34 @@
+//
+//  ServerUnreachable.swift
+//  Remote Text
+//
+//  Created by Sam Gauck on 5/2/23.
+//
+
+import Foundation
+import SwiftUI
+
+extension View {
+    func unreachable(_ unreachable: Bool) -> some View {
+        if unreachable {
+            return AnyView(ZStack {
+                self
+                VStack {
+                    Spacer()
+                    HStack {
+                        Spacer()
+                        Text("Server Unreachable")
+                            .font(.body.lowercaseSmallCaps())
+                            .padding()
+                            .background(.red)
+                            .cornerRadius(5)
+                            .transition(.asymmetric(insertion: .push(from: .bottom), removal: .scale))
+                        Spacer()
+                    }
+                }
+            })
+        } else {
+            return AnyView(self)
+        }
+    }
+}

--- a/Remote Text/Structs.swift
+++ b/Remote Text/Structs.swift
@@ -13,7 +13,7 @@ struct File: Identifiable, Codable {
   let content: String
 }
 
-struct FileSummary: Identifiable, Codable {
+struct FileSummary: Identifiable, Codable, Hashable {
   let name: String
   let id: UUID
   let editedTime: Date


### PR DESCRIPTION
Closes #7.

Rather than the navigational hodgepodge that the app is currently, this PR refactors it to be data-based. There is now a stack of `ContentView.Navigation` enums, which directly represent the contents of the navigation stack. This allows functionality such as swapping from the file creation view to the file editing view[^1], supporting a "Save & Preview" button (by pushing another view onto the stack programmatically), and more.

Making use of this new functionality, in the "Create New File" view, users now have the option to create the file and preview it immediately, create the file and jump to the editor, or create the file and close it. Likewise, in the file editor view, while the behavior remains to have only a "Preview" button when no changes have been made, if the file has been changed there are options to save and preview, save and continue working, or save and close.

[^1]: Note that this currently animates strangely. It may actually be best to have the file creation and file editing views be the same view in code, determined by a `@State` boolean. Further investigation is required.